### PR TITLE
Update to pyside6.

### DIFF
--- a/3D/qt3d_minimal.py
+++ b/3D/qt3d_minimal.py
@@ -4,66 +4,46 @@ import os.path
 import struct
 import multiprocessing
 
-try:
-    from PyQt5.QtCore import *
-    from PyQt5.QtGui import *
-    from PyQt5.QtWidgets import *
-    from PyQt5.Qt3DCore import *
-    from PyQt5.Qt3DExtras import *
-    from PyQt5.Qt3DRender import *
-except Exception:
-    from PySide2.QtGui import *
-    from PySide2.QtCore import *
-    from PySide2.QtWidgets import *
-    from PySide2.Qt3DCore import *
-    from PySide2.Qt3DExtras import *
-    from PySide2.Qt3DRender import *
+from PySide6.QtCore import (Property, QObject, QPropertyAnimation, Signal)
+from PySide6.QtGui import (QGuiApplication, QMatrix4x4, QQuaternion, QVector3D)
+from PySide6.Qt3DCore import Qt3DCore
+from PySide6.Qt3DExtras import Qt3DExtras
+from PySide6.Qt3DRender import Qt3DRender
 
 import ifcopenshell
 import ifcopenshell.geom
 
 
-class View3D(QWidget):
+class View3D(Qt3DExtras.Qt3DWindow):
     """
     3D View Widget
     - V1 = IFC File Loading, geometry parsing & basic navigation
     """
     def __init__(self):
-        QWidget.__init__(self)
-
+        super().__init__()
         # variables
         self.ifc_file = None
         self.start = time.time()
 
-        # 3D View
-        self.view = Qt3DWindow()
-        self.view.defaultFrameGraph().setClearColor(QColor("#4466ff"))
-        self.container = self.createWindowContainer(self.view)
-        self.container.setMinimumSize(QSize(200, 100))
-        self.container.setFocusPolicy(Qt.NoFocus)
-
-        # Prepare our scene
-        self.root = QEntity()
-        self.material = QPerVertexColorMaterial()
-        self.root.addComponent(self.material)
-        self.material.setShareable(True)
         self.initialise_camera()
-        self.view.setRootEntity(self.root)
 
-        # Finish GUI
-        layout = QHBoxLayout()
-        layout.addWidget(self.container)
-        self.setLayout(layout)
+        self.setRootEntity(self.rootEntity)
 
     def initialise_camera(self):
         # camera
-        camera = self.view.camera()
+        camera = self.camera()
         camera.lens().setPerspectiveProjection(45.0, 16.0 / 9.0, 0.1, 1000)
         camera.setPosition(QVector3D(0, 0, 40))
         camera.setViewCenter(QVector3D(0, 0, 0))
 
         # for camera control
-        cam_controller = QOrbitCameraController(self.root)
+        # Root entity
+        self.rootEntity = Qt3DCore.QEntity()
+
+        # Material
+        self.material = Qt3DExtras.QPerVertexColorMaterial(self.rootEntity)
+
+        cam_controller = Qt3DExtras.QOrbitCameraController(self.rootEntity)
         cam_controller.setLinearSpeed(50.0)
         cam_controller.setLookSpeed(180.0)
         cam_controller.setCamera(camera)
@@ -123,39 +103,40 @@ class View3D(QWidget):
         geometry = shape.geometry
 
         # buffer example https://stackoverflow.com/questions/49049828/numpy-array-via-qbuffer-to-qgeometry
-        custom_mesh_renderer = QGeometryRenderer()
-        custom_mesh_renderer.setPrimitiveType(QGeometryRenderer.Triangles)
-        custom_geometry = QGeometry(custom_mesh_renderer)
+        custom_mesh_entity = Qt3DCore.QEntity(self.rootEntity)
+        custom_mesh_renderer = Qt3DRender.QGeometryRenderer(custom_mesh_entity)
+        custom_mesh_renderer.setPrimitiveType(Qt3DRender.QGeometryRenderer.PrimitiveType.Triangles)
+        custom_geometry = Qt3DCore.QGeometry(custom_mesh_entity)
 
         # Position Attribute
-        position_data_buffer = QBuffer(QBuffer.VertexBuffer, custom_geometry)
+        position_data_buffer = Qt3DCore.QBuffer(custom_geometry)
         # position_data_buffer.setData(QByteArray(np.array(geometry.verts).astype(np.float32).tobytes()))
         position_data_buffer.setData(struct.pack('%sf' % len(geometry.verts), *geometry.verts))
-        position_attribute = QAttribute()
-        position_attribute.setAttributeType(QAttribute.VertexAttribute)
+        position_attribute = Qt3DCore.QAttribute(custom_geometry)
+        position_attribute.setAttributeType(Qt3DCore.QAttribute.AttributeType.VertexAttribute)
         position_attribute.setBuffer(position_data_buffer)
-        position_attribute.setVertexBaseType(QAttribute.Float)
+        position_attribute.setVertexBaseType(Qt3DCore.QAttribute.VertexBaseType.Float)
         position_attribute.setVertexSize(3)  # 3 floats
         position_attribute.setByteOffset(0)  # start from first index
         position_attribute.setByteStride(3 * 4)  # 3 coordinates and 4 as length of float32 in bytes
         position_attribute.setCount(len(geometry.verts))  # vertices
-        position_attribute.setName(QAttribute.defaultPositionAttributeName())
+        position_attribute.setName(Qt3DCore.QAttribute.defaultPositionAttributeName())
         custom_geometry.addAttribute(position_attribute)
 
         # Normal Attribute
         if len(geometry.normals) > 0:
-            normals_data_buffer = QBuffer(QBuffer.VertexBuffer, custom_geometry)
+            normals_data_buffer = Qt3DCore.QBuffer(custom_geometry)
             # normals_data_buffer.setData(QByteArray(np.array(geometry.normals).astype(np.float32).tobytes()))
             normals_data_buffer.setData(struct.pack('%sf' % len(geometry.normals), *geometry.normals))
-            normal_attribute = QAttribute()
-            normal_attribute.setAttributeType(QAttribute.VertexAttribute)
+            normal_attribute = Qt3DCore.QAttribute(custom_geometry)
+            normal_attribute.setAttributeType(Qt3DCore.QAttribute.VertexAttribute)
             normal_attribute.setBuffer(normals_data_buffer)
-            normal_attribute.setVertexBaseType(QAttribute.Float)
+            normal_attribute.setVertexBaseType(Qt3DCore.QAttribute.VertexBaseType.Float)
             normal_attribute.setVertexSize(3)  # 3 floats
             normal_attribute.setByteOffset(0)  # start from first index
             normal_attribute.setByteStride(3 * 4)  # 3 coordinates and 4 as length of float32 in bytes
             normal_attribute.setCount(len(geometry.normals))  # vertices
-            normal_attribute.setName(QAttribute.defaultNormalAttributeName())
+            normal_attribute.setName(Qt3DCore.QAttribute.defaultNormalAttributeName())
             custom_geometry.addAttribute(normal_attribute)
 
         # Collect the colors via the materials (1 color per vertex)
@@ -165,6 +146,7 @@ class View3D(QWidget):
             red = 0.5
             green = 1.0
             blue = 0.5
+            alpha = 1.0
             # From material index we get the material reference ID
             mat_id = geometry.material_ids[material_index]
             # Beware... this id can be -1 - so use a default color instead
@@ -181,27 +163,27 @@ class View3D(QWidget):
                 color_list[vertex * 3 + 2] = blue
 
         # Color Attribute
-        color_data_buffer = QBuffer(QBuffer.VertexBuffer, custom_geometry)
+        color_data_buffer = Qt3DCore.QBuffer(custom_geometry)
         # color_data_buffer.setData(QByteArray(np.array(color_list).astype(np.float32).tobytes()))
         color_data_buffer.setData(struct.pack('%sf' % len(color_list), *color_list))
-        color_attribute = QAttribute()
-        color_attribute.setAttributeType(QAttribute.VertexAttribute)
+        color_attribute = Qt3DCore.QAttribute(custom_geometry)
+        color_attribute.setAttributeType(Qt3DCore.QAttribute.VertexAttribute)
         color_attribute.setBuffer(color_data_buffer)
-        color_attribute.setVertexBaseType(QAttribute.Float)
+        color_attribute.setVertexBaseType(Qt3DCore.QAttribute.VertexBaseType.Float)
         color_attribute.setVertexSize(3)  # 3 floats
         color_attribute.setByteOffset(0)  # start from first index
         color_attribute.setByteStride(3 * 4)  # 3 coordinates and 4 as length of float32 in bytes
         color_attribute.setCount(len(color_list))  # colors (per vertex)
-        color_attribute.setName(QAttribute.defaultColorAttributeName())
+        color_attribute.setName(Qt3DCore.QAttribute.defaultColorAttributeName())
         custom_geometry.addAttribute(color_attribute)
 
         # Faces Index Attribute
-        index_data_buffer = QBuffer(QBuffer.IndexBuffer, custom_geometry)
+        index_data_buffer = Qt3DCore.QBuffer(custom_geometry)
         # index_data_buffer.setData(QByteArray(np.array(geometry.faces).astype(np.uintc).tobytes()))
         index_data_buffer.setData(struct.pack("{}I".format(len(geometry.faces)), *geometry.faces))
-        index_attribute = QAttribute()
-        index_attribute.setVertexBaseType(QAttribute.UnsignedInt)
-        index_attribute.setAttributeType(QAttribute.IndexAttribute)
+        index_attribute = Qt3DCore.QAttribute(custom_geometry)
+        index_attribute.setVertexBaseType(Qt3DCore.QAttribute.VertexBaseType.UnsignedInt)
+        index_attribute.setAttributeType(Qt3DCore.QAttribute.IndexAttribute)
         index_attribute.setBuffer(index_data_buffer)
         index_attribute.setCount(len(geometry.faces))
         custom_geometry.addAttribute(index_attribute)
@@ -214,30 +196,27 @@ class View3D(QWidget):
         custom_mesh_renderer.setFirstInstance(0)
 
         # add everything to the scene
-        custom_mesh_entity = QEntity(self.root)
         custom_mesh_entity.addComponent(custom_mesh_renderer)
-        transform = QTransform()
-        transform.setRotationX(-90)
-        custom_mesh_entity.addComponent(transform)
+        custom_transform = Qt3DCore.QTransform(custom_geometry)
+        custom_transform.setRotationX(-90)
+        custom_mesh_entity.addComponent(custom_transform)
         custom_mesh_entity.addComponent(self.material)
 
 
 # Our Main function
 def main():
-    app = 0
-    if QApplication.instance():
-        app = QApplication.instance()
-    else:
-        app = QApplication(sys.argv)
-
+    app = QGuiApplication(sys.argv)
     w = View3D()
     w.resize(1280, 800)
-    filename = sys.argv[1]
+    filename = "IfcOpenHouse_IFC4.ifc"
+    if len(sys.argv) > 1:
+        filename = sys.argv[1]
+        
     if os.path.isfile(filename):
         w.load_file(filename)
-        w.setWindowTitle("IFC Viewer - " + filename)
-        w.show()
-    sys.exit(app.exec_())
+        w.setTitle("IFC Viewer - " + filename)
+    w.show()
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/GUI/ifc_schemaviewer.py
+++ b/GUI/ifc_schemaviewer.py
@@ -1,5 +1,7 @@
 import sys
-from PyQt5.QtWidgets import *
+from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QSizePolicy,
+                                QSpacerItem, QSpinBox, QTreeWidget, QTreeWidgetItem,
+                                QHBoxLayout, QVBoxLayout, QWidget)
 import ifcopenshell
 
 
@@ -24,7 +26,7 @@ class SchemaViewer(QWidget):
         self.current_schema = 'IFC2X3'
         self.schema_chooser = QComboBox()
         self.schema_chooser.addItems(['IFC2X3', 'IFC4', 'IFC4x1','IFC4x2','IFC4x3_rc1','IFC4x3_rc2','IFC4x3_rc3','IFC4x3_rc4'])
-        self.schema_chooser.activated[str].connect(self.set_schema)
+        self.schema_chooser.textActivated.connect(self.set_schema)
         hbox.addWidget(self.schema_chooser)
 
         # Column Count Chooser
@@ -218,4 +220,4 @@ if __name__ == '__main__':
     w = SchemaViewer()
     w.resize(600, 800)
     w.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/GUI/ifc_treeviewer.py
+++ b/GUI/ifc_treeviewer.py
@@ -1,13 +1,6 @@
 import sys
 import os.path
-try:
-    from PyQt5.QtCore import *
-    from PyQt5.QtGui import *
-    from PyQt5.QtWidgets import *
-except Exception:
-    from PySide2.QtGui import *
-    from PySide2.QtCore import *
-    from PySide2.QtWidgets import *
+from PySide6.QtWidgets import (QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 import ifcopenshell
 
 
@@ -60,4 +53,4 @@ if __name__ == '__main__':
     if os.path.isfile(filename):
         w.load_file(filename)
         w.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/GUI/ifc_treeviewer2.py
+++ b/GUI/ifc_treeviewer2.py
@@ -1,14 +1,6 @@
 import sys
 import os.path
-
-try:
-    from PyQt5.QtCore import *
-    from PyQt5.QtGui import *
-    from PyQt5.QtWidgets import *
-except Exception:
-    from PySide2.QtGui import *
-    from PySide2.QtCore import *
-    from PySide2.QtWidgets import *
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 import ifcopenshell
 
 
@@ -150,4 +142,4 @@ if __name__ == '__main__':
     if os.path.isfile(filename):
         w.load_file(filename)
         w.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/README.md
+++ b/README.md
@@ -7,4 +7,18 @@ See the Wiki for more in-depth explanation for the different examples.
 
 A second objective is to collect all examples into one, more comprehensive IFC-viewer.
 
+# Setup
+use pip to install pyside6 to get PySide6, PySide6-Essentials and PySide6-Addons.
+```
+micromamba create -n bim python=3.11
+micromamba activate bim
+pip install pyside6 lark ifcopenshell
+python 3D/qt3d_minimal.py IfcOpenHouse_IFC4.ifc
+```
+test qt3d_minimal.py with [IfcOpenHouse_IFC4.ifc](https://github.com/aothms/IfcOpenHouse)
+```
+python 3D/qt3d_minimal.py IfcOpenHouse_IFC4.ifc
+```
+
+
 


### PR DESCRIPTION
I successfully resovle the issues to display the model with pyside6. It is essenstial to add rootEntity or custom_entity (or just bind to self) to QGeometryRenderer to make the mesh appear. And the same for QBuffer and QAttribute. This may be related to how Qt 3D scence (QNode) is rendered. 
One big issue: memory leak!! even the [simple3d sample](https://doc.qt.io/qtforpython-6/examples/example_3d_simple3d.html) is eating up all the memory (XXGB) on m1 macbook in seconds. So it's probaly pyside6's issue.